### PR TITLE
EmptyView label added

### DIFF
--- a/EvercodeApp/Screens/Components/EmptyView.swift
+++ b/EvercodeApp/Screens/Components/EmptyView.swift
@@ -2,5 +2,43 @@ import UIKit
 
 class EmptyView: UIView {
     
-    // TODO
+    private lazy var label: UILabel = {
+       
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 22, weight: .semibold)
+        label.text = "No data found"
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var activityIndicatorView: UIActivityIndicatorView = {
+      
+        let view = UIActivityIndicatorView(style: .large)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.startAnimating()
+        return view
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        
+        self.backgroundColor = .white
+        
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureConstraints() {
+        addSubview(label)
+        NSLayoutConstraint.activate([
+        
+            label.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        ])
+    }
+    
 }


### PR DESCRIPTION
 
## Describe your changes 

- EmptyView label added
 
## Checklist before requesting a review

Put an "X" in the boxes that apply.

- [X] I have performed a self-review of my code
- [X] New and existing unit tests pass locally with my changes
- [X] Does not contain commented code
 
## Screenshots (if appropriate)

![Screenshot 2023-05-08 at 18 02 48](https://user-images.githubusercontent.com/103609951/236934490-0d067523-10e8-47be-b5fd-c8d5af035490.png)

